### PR TITLE
Css fix

### DIFF
--- a/resources/sass/filter.scss
+++ b/resources/sass/filter.scss
@@ -42,6 +42,3 @@
   width: 100%;
 }
 
-.scroll-wrap {
-  &.overflow-x-hidden { overflow: unset !important; }
-}


### PR DESCRIPTION
Deleting this css lines fixed issue in Laravel Nova 3.x where popover with multiple filters did not show scrollbar.